### PR TITLE
Multiple markdown file support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,12 @@ USAGE:
 FLAGS:
   -t, --title
   -f  --format
+  -d  --dir
 ```
 
-Using the ``build`` command alone will build the book as is and output ``book.epub``. If ``ryubook.toml`` is present or ``--title`` is used then name of your choice will be used. You can also build formats other then the default ``epub`` by passing `-f` or ``--format``.
+Using the ``build`` command alone will build the book as is and output ``book.epub``. You can also build formats other then the default ``epub`` by passing `-f` or ``--format``. In build, ``-d`` or ``--dir`` allows for building a book outside of the current directory.
+
+Note the book name is currently grabbed from the current or specified directory and not from ``title.txt``. This is a limitation in Ryubook and NOT Pandoc.
 
 ### Supported formats
 
@@ -64,17 +67,19 @@ USAGE:
 FLAGS:
   -t --title
   -a  --author
+  -d  --dir
 ```
 
-By passing ``-t`` or ``-a`` you can Ryubook will write metadata of the book to ``title.txt``.
+Init will create ``/src/title.txt``, ``/src/01-helloworld.md``, and a ``.gitignore``. By passing ``-t`` or ``-a`` Ryubook will write the title and author, respectfully, to the ``title.txt``. In Init, ``-d`` or ``--dir`` allows for creating a book project of the current directory.
 
 ### title.txt
 
 ```txt
-% Book Title
-% Author
+---
+title: Book Title
+author: Lorem Ipsum
+language: en-US
+---
 ```
 
-The book's metadata is contained in ``title.txt``. Title and author are on separate lines with a ``%`` before each word.
-
-
+The book's metadata is contained in ``title.txt`` and will be read by Pandoc. Ryubook assumes the language based on your relative location. In this example, it choose ``en-US`` because my native language is English and I live in the US.

--- a/src/RyuBook/AppConsts.cs
+++ b/src/RyuBook/AppConsts.cs
@@ -1,14 +1,8 @@
-using System;
-using System.IO;
-
 namespace RyuBook
 {
     public struct AppConsts
     {
         public const string MetadateFile = "title.txt";
-        public const string FirstChapterFile = "01-chapter1.md";
-
-        public static readonly string BuildPath = Path.Combine(Environment.CurrentDirectory, "build");
-        public static readonly string SrcPath = Path.Combine(Environment.CurrentDirectory, "src");
+        public const string FirstChapterFile = "01-helloworld.md";
     }
 }

--- a/src/RyuBook/AppConsts.cs
+++ b/src/RyuBook/AppConsts.cs
@@ -6,10 +6,9 @@ namespace RyuBook
     public struct AppConsts
     {
         public const string MetadateFile = "title.txt";
-        public const string ContentFile = "book.md";
-        public const string ProjectFile = "ryubook.toml";
+        public const string FirstChapterFile = "01-chapter1.md";
 
         public static readonly string BuildPath = Path.Combine(Environment.CurrentDirectory, "build");
-        public static readonly string  SrcPath = Path.Combine(Environment.CurrentDirectory, "src");
+        public static readonly string SrcPath = Path.Combine(Environment.CurrentDirectory, "src");
     }
 }

--- a/src/RyuBook/Options.cs
+++ b/src/RyuBook/Options.cs
@@ -1,19 +1,25 @@
+using System;
 using CommandLine;
 
 namespace RyuBook
 {
+    class BaseOptions
+    {
+        [Option('d', "dir")] public string Directory { get; set; } = Environment.CurrentDirectory;
+    }
+
     [Verb("build", HelpText = "Compiles the book as a ePub.")]
-    class BuildOption
+    class BuildOption : BaseOptions
     {
         [Option('t', "title")] public string Title { get; set; } = string.Empty;
         [Option('f', "format")] public string Format { get; set; } = string.Empty;
     }
 
     [Verb("clean", HelpText = "Removes all books in the /build directory.")]
-    class CleanOption {}
+    class CleanOption : BaseOptions { }
 
     [Verb("init", HelpText = "Creates a new project.")]
-    class InitOption
+    class InitOption : BaseOptions
     {
         [Option('a', "author")] public string Author { get; set; } = string.Empty;
         [Option('t', "title")] public string Title { get; set; } = string.Empty;

--- a/src/RyuBook/PandocEnviroment.cs
+++ b/src/RyuBook/PandocEnviroment.cs
@@ -3,9 +3,9 @@ using System.IO;
 
 namespace RyuBook
 {
-    public struct EnviromentCheck
+    public struct PandocEnviroment
     {
-        static bool IsPandoc
+        public static bool IfPandocExists
         {
             get
             {
@@ -22,22 +22,6 @@ namespace RyuBook
                     return true;
                 }
                 catch { return false; }
-            }
-        }
-
-        public static bool IsSrcDirectory => Directory.Exists(AppConsts.SrcPath);
-
-        public static bool IsSrcDirAndPandoc
-        {
-            get
-            {
-                try
-                {
-                   return IsSrcDirectory && IsPandoc;
-
-                }
-                catch { return false; }
-
             }
         }
     }

--- a/src/RyuBook/Program.cs
+++ b/src/RyuBook/Program.cs
@@ -38,10 +38,10 @@ namespace RyuBook
                 })
                 .WithParsed<InitOption>(o =>
                 {
-                    // If source directory exists, exit
-                    if (EnviromentCheck.IsSrcDirectory) return;
-
                     var srcDir = Path.Combine(o.Directory, "src");
+
+                    // If source directory exists, exit
+                    if (Directory.Exists(srcDir)) return;
 
                     // Files
                     var metadataFile = Path.Combine(srcDir, AppConsts.MetadateFile);
@@ -102,7 +102,7 @@ namespace RyuBook
                             var bookTitle = metaDateFile.First()
                             .Replace("title:\u0020", string.Empty);
 
-                            if (!EnviromentCheck.IsSrcDirAndPandoc) return;
+                            if (!PandocEnviroment.IfPandocExists && !Directory.Exists(srcDir)) return;
 
                             if (o.Format.Contains("doc", StringComparison.OrdinalIgnoreCase)
                                 || o.Format.Contains("docx", StringComparison.OrdinalIgnoreCase))

--- a/src/RyuBook/Properties/launchSettings.json
+++ b/src/RyuBook/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "RyuBook": {
             "commandName": "Project",
-            "commandLineArgs": "build -f list"
+            "commandLineArgs": "help"
         }
     }
 }

--- a/src/RyuBook/RyuBook.csproj
+++ b/src/RyuBook/RyuBook.csproj
@@ -7,8 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CommandLineParser" Version="2.7.82" />
-      <PackageReference Include="Nett" Version="0.15.0" />
+      <PackageReference Include="CommandLineParser" Version="2.8.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This update adds support for building multiple markdown files in alphabetical order so chapters can be properly spread out per-file instead of the former monolithic ``book.md`` method. The monolithic method was going to removed, regardless, because it doesn't scale well, but it helped provide a good foundation. 

This also makes it more compatible with [The Little Go Book](https://github.com/karlseguin/the-little-go-book) (it's build process inspired this program) now that Ryubook registers any available markdown files automatically instead of relying on something hard-coded.
 
- Removed A LOT of redundant code
- Removed reference to Nett
- Metadata file is now more explicit
- Init will now generate a .gitignore
- Support for building outside of the current directory (useful for debugging)
- There is no more ``/build`` because Pandoc wouldn't output to it with multiple files